### PR TITLE
feat(nx-cloud): set up nx workspace

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -12,7 +12,7 @@
       "{workspaceRoot}/.github/workflows/ci.yml"
     ]
   },
-  "nxCloudId": "6896094743747b33f885583d",
+  "nxCloudId": "68960b07e5b4bdab639eaa3e",
   "plugins": [
     {
       "plugin": "@nx/js/typescript",
@@ -28,5 +28,6 @@
         }
       }
     }
-  ]
+  ],
+  "nxCloudUrl": "https://staging.nx.app"
 }


### PR DESCRIPTION
feat(nx-cloud): setup nx cloud workspace

This commit sets up Nx Cloud for your Nx workspace, enabling distributed caching and the Nx Cloud GitHub integration for fast CI and improved developer experience.

You can access your Nx Cloud workspace by going to
https://staging.nx.app/orgs/667ab290ce80ba48e88df65a/workspaces/68960b07e5b4bdab639eaa3e

**Note:** This commit attempts to maintain formatting of the nx.json file, however you may need to correct formatting by running an nx format command and committing the changes.